### PR TITLE
install_requires += 'js.deform-bootstrap'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     install_requires=[
         'Kotti>=0.9a1',
         'kotti_settings>=0.1a4',
+        'js.deform-bootstrap>=0.2.6',
     ],
     entry_points={
         'fanstatic.libraries': [


### PR DESCRIPTION
because it seems to rely on it.

```
  File "/Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/kotti_contentpreview/fanstatic.py", line 8, in <module>
    from js.deform_bootstrap import deform_bootstrap_js
ImportError: No module named deform_bootstrap

[marca@marca-mac2 kotti_contentpreview]$ ag deform_bootstrap
kotti_contentpreview/fanstatic.py
8:from js.deform_bootstrap import deform_bootstrap_js
21:    depends=[deform_bootstrap_js],
```
