### PR TITLE
README.rst: Link to kotti_settings more simply

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Setup
 To activate the ``kotti_contentpreview`` add-on in your Kotti site, you need to
 add an entry to the ``kotti.configurators`` setting in your Paste
 Deploy config.  If you don't have a ``kotti.configurators`` option,
-add one. ``kotti_contentpreview`` depends on ``kotti_settings``, so you have to
-add also an entry for this add-on. `Here you find out more`_ about ``kotti_settings``.
+add one. ``kotti_contentpreview`` depends on kotti_settings_, so you have to
+add also an entry for this add-on.
 The line in your ``[app:main]`` (or ``[app:kotti]``, depending on how
 you setup Fanstatic) section could then look like this:::
 
@@ -28,4 +28,4 @@ and hiding of the window on the settings page. Point your browser to
 http://your.domain/@@settings to get to the settingspage or use the submenupoint of 'Site Setup'.
 
 .. _Find out more about Kotti: http://pypi.python.org/pypi/Kotti
-.. _Here you find out more: http://pypi.python.org/pypi/kotti_settings
+.. _kotti_settings: http://pypi.python.org/pypi/kotti_settings


### PR DESCRIPTION
Just link on first mention instead of adding an extra sentence for it.

Preview at https://github.com/msabramo/kotti_contentpreview/blob/patch-1/README.rst
